### PR TITLE
compact solver + sleeping

### DIFF
--- a/mujoco_warp/_src/cli.py
+++ b/mujoco_warp/_src/cli.py
@@ -48,12 +48,7 @@ ENABLE_ISLANDS = flags.DEFINE_bool(
   False,
   "Enable constraint islands solver",
 )
-NV_COMPACT = flags.DEFINE_bool(
-  "nv_compact",
-  False,
-  "Enable experimental nv_compact (compact active DOFs into nv_max-sized factor/solve)",
-)
-NV_MAX = flags.DEFINE_integer("nv_max", None, "capacity for compacted active DOFs per world (nv_compact)")
+NVMAX = flags.DEFINE_integer("nvmax", None, "maximum active DOFs per world")
 
 
 DEVICE = flags.DEFINE_string("device", None, "override the default Warp device")
@@ -148,7 +143,6 @@ def init_structs(
 ) -> Tuple[mjw.Model, mjw.Data, mjw.RenderContext | None, list[np.ndarray] | None]:
   """Initialize device structs."""
   io.ENABLE_ISLANDS = ENABLE_ISLANDS.value
-  io.ENABLE_NV_COMPACT = NV_COMPACT.value
 
   mjd = mujoco.MjData(mjm)
   ctrls = None
@@ -173,7 +167,7 @@ def init_structs(
       njmax=NJMAX.value,
       njmax_nnz=NJMAX_NNZ.value,
       nccdmax=NCCDMAX.value,
-      nv_max=NV_MAX.value,
+      nvmax=NVMAX.value,
     )
 
     if mjw.RenderContext not in get_type_hints(fn).values():

--- a/mujoco_warp/_src/collision_driver.py
+++ b/mujoco_warp/_src/collision_driver.py
@@ -625,7 +625,9 @@ def sap_broadphase(m: Model, d: Data, ctx: CollisionContext, skip: Optional[wp.a
   """
   nworldgeom = d.nworld * m.ngeom
   skip_in = skip if skip is not None else wp.ones(1, dtype=int)
-  enable_sleep = bool(m.opt.enableflags & EnableBit.SLEEP)
+  enable_sleep = (d.nvmax < m.nv) or bool(
+    not (m.opt.disableflags & DisableBit.ISLAND) and (m.opt.enableflags & EnableBit.SLEEP)
+  )
 
   # TODO(team): direction
 
@@ -719,7 +721,6 @@ def _nxn_broadphase(
   ngeom_margin: int,
   ngeom_gap: int,
   enable_sleep: bool = False,
-  nv_compact: bool = False,
 ):
   @wp.kernel(module="unique", enable_backward=False)
   def kernel(
@@ -737,7 +738,6 @@ def _nxn_broadphase(
     geom_xpos_in: wp.array2d[wp.vec3],
     geom_xmat_in: wp.array2d[wp.mat33],
     body_awake_in: wp.array2d[int],
-    tree_active_in: wp.array2d[bool],
     naconmax_in: int,
     # In:
     skip_in: wp.array[int],
@@ -757,17 +757,6 @@ def _nxn_broadphase(
     geom = nxn_geom_pair[elementid]
     geom1 = geom[0]
     geom2 = geom[1]
-
-    # nv_compact: skip pairs where both bodies are asleep. Neither moves, so no new contact
-    # is possible and any resting contact is moot (both frozen). A moving body contacting a
-    # sleeper is a pair with one active tree, so it is kept and wakes the sleeper.
-    if wp.static(nv_compact):
-      t1 = body_treeid[geom_bodyid[geom1]]
-      t2 = body_treeid[geom_bodyid[geom2]]
-      a1 = t1 >= 0 and tree_active_in[worldid, t1]
-      a2 = t2 >= 0 and tree_active_in[worldid, t2]
-      if not (a1 or a2):
-        return
 
     if wp.static(enable_sleep):
       b1 = geom_bodyid[geom1]
@@ -816,7 +805,9 @@ def nxn_broadphase(m: Model, d: Data, ctx: CollisionContext, skip: Optional[wp.a
   The initial list of pairs is filtered at model creation time to exclude pairs based on
   `contype`/`conaffinity`, parent-child relationships, and explicit `<exclude>` tags.
   """
-  enable_sleep = bool(m.opt.enableflags & EnableBit.SLEEP)
+  enable_sleep = (d.nvmax < m.nv) or bool(
+    not (m.opt.disableflags & DisableBit.ISLAND) and (m.opt.enableflags & EnableBit.SLEEP)
+  )
   skip_in = skip if skip is not None else wp.ones(1, dtype=int)
   wp.launch(
     _nxn_broadphase(
@@ -826,7 +817,6 @@ def nxn_broadphase(m: Model, d: Data, ctx: CollisionContext, skip: Optional[wp.a
       m.geom_margin.shape[0],
       m.geom_gap.shape[0],
       enable_sleep,
-      m.opt.nv_compact,
     ),
     dim=(d.nworld, m.nxn_geom_pair_filtered.shape[0]),
     inputs=[
@@ -842,7 +832,6 @@ def nxn_broadphase(m: Model, d: Data, ctx: CollisionContext, skip: Optional[wp.a
       d.geom_xpos,
       d.geom_xmat,
       d.body_awake,
-      d.tree_active,
       d.naconmax,
       skip_in,
     ],
@@ -900,7 +889,9 @@ def collision(m: Model, d: Data, skip: Optional[wp.array] = None):
   # TODO(team): create context outside collision?
   ctx = create_collision_context(d.naconmax)
   skip_in = skip if skip is not None else wp.ones(1, dtype=int)
-  enable_sleep = bool(m.opt.enableflags & EnableBit.SLEEP)
+  enable_sleep = (d.nvmax < m.nv) or bool(
+    not (m.opt.disableflags & DisableBit.ISLAND) and (m.opt.enableflags & EnableBit.SLEEP)
+  )
 
   # zero counters
   wp.launch(_zero_nacon_ncollision(enable_sleep), dim=1, inputs=[skip_in], outputs=[d.nacon, d.ncollision])

--- a/mujoco_warp/_src/constraint.py
+++ b/mujoco_warp/_src/constraint.py
@@ -1906,10 +1906,9 @@ def _limit_tendon(
 
 
 @cache_kernel
-def _efc_contact_init(cone_type: types.ConeType, is_sparse: bool, nv_compact: bool = False):
+def _efc_contact_init(cone_type: types.ConeType, is_sparse: bool):
   IS_ELLIPTIC = cone_type == types.ConeType.ELLIPTIC
   IS_SPARSE = is_sparse
-  NV_COMPACT = nv_compact
 
   @wp.kernel(module="unique", enable_backward=False)
   def kernel(
@@ -1923,7 +1922,6 @@ def _efc_contact_init(cone_type: types.ConeType, is_sparse: bool, nv_compact: bo
     flex_vertadr: wp.array[int],
     flex_vertbodyid: wp.array[int],
     # Data in:
-    tree_active_in: wp.array2d[bool],
     njmax_in: int,
     njmax_nnz_in: int,
     nacon_in: wp.array[int],
@@ -1971,30 +1969,6 @@ def _efc_contact_init(cone_type: types.ConeType, is_sparse: bool, nv_compact: bo
         ndim = 2 * (condim - 1)
 
     worldid = worldid_in[conid]
-
-    # nv_compact: skip contacts whose bodies are all inactive. Such a row would have
-    # an all-zero compacted Jacobian but a nonzero residual, injecting an irreducible
-    # cost the Newton solver cannot reduce (it never converges). A geom on the static
-    # world (tree -1) counts as inactive; flex contacts are always kept.
-    if wp.static(NV_COMPACT):
-      cgeom = geom_in[conid]
-      keep = False
-      if cgeom[0] >= 0:
-        t = body_treeid[geom_bodyid[cgeom[0]]]
-        if t >= 0 and tree_active_in[worldid, t]:
-          keep = True
-      else:
-        keep = True
-      if cgeom[1] >= 0:
-        t = body_treeid[geom_bodyid[cgeom[1]]]
-        if t >= 0 and tree_active_in[worldid, t]:
-          keep = True
-      else:
-        keep = True
-      if not keep:
-        for dim in range(ndim):
-          contact_efc_address_out[conid, dim] = -1
-        return
 
     # Allocate contiguous block of efcids for all dimids
     base_efcid = wp.atomic_add(nefc_out, worldid, ndim)
@@ -3012,7 +2986,7 @@ def make_constraint(m: types.Model, d: types.Data):
       )
 
       wp.launch(
-        _efc_contact_init(m.opt.cone, m.is_sparse, m.opt.nv_compact),
+        _efc_contact_init(m.opt.cone, m.is_sparse),
         dim=d.naconmax,
         inputs=[
           m.body_weldid,
@@ -3023,7 +2997,6 @@ def make_constraint(m: types.Model, d: types.Data):
           m.geom_bodyid,
           m.flex_vertadr,
           m.flex_vertbodyid,
-          d.tree_active,
           d.njmax,
           d.njmax_nnz,
           d.nacon,

--- a/mujoco_warp/_src/forward.py
+++ b/mujoco_warp/_src/forward.py
@@ -331,7 +331,8 @@ def _advance(m: Model, d: Data, qacc: wp.array, qvel: Optional[wp.array] = None)
 
   wp.copy(d.qacc_warmstart, d.qacc)
 
-  if not (m.opt.disableflags & DisableBit.ISLAND) and (m.opt.enableflags & EnableBit.SLEEP):
+  sleep_enabled = (d.nvmax < m.nv) or (not (m.opt.disableflags & DisableBit.ISLAND) and (m.opt.enableflags & EnableBit.SLEEP))
+  if sleep_enabled:
     sleep.sleep(m, d)
     fwd_velocity(m, d)
     sleep.update_sleep(m, d)
@@ -666,7 +667,7 @@ def fwd_position(m: Model, d: Data, factorize: bool = True):
   smooth.flex(m, d)
   smooth.tendon(m, d)
 
-  sleep_enabled = not (m.opt.disableflags & DisableBit.ISLAND) and (m.opt.enableflags & EnableBit.SLEEP)
+  sleep_enabled = (d.nvmax < m.nv) or (not (m.opt.disableflags & DisableBit.ISLAND) and (m.opt.enableflags & EnableBit.SLEEP))
 
   if sleep_enabled and m.ntendon > 0:
     sleep.wake_tendon(m, d)
@@ -696,7 +697,7 @@ def fwd_position(m: Model, d: Data, factorize: bool = True):
       sleep.wake_equality(m, d)
     sleep.update_sleep(m, d)
 
-  if m.ntree > 1 and not (m.opt.disableflags & types.DisableBit.ISLAND):
+  if (d.nvmax < m.nv) or (m.ntree > 1 and not (m.opt.disableflags & types.DisableBit.ISLAND)):
     island.island(m, d)
   smooth.transmission(m, d)
 
@@ -1334,7 +1335,7 @@ def fwd_acceleration(m: Model, d: Data, factorize: bool = False):
   )
   xfrc_accumulate(m, d, d.qfrc_smooth)
 
-  if m.opt.nv_compact:
+  if d.nvmax < m.nv:
     # update the active-DOF set (needs contacts from fwd_position) and solve
     # the smooth acceleration in compacted dense space.
     nvmax.update_active_dofs(m, d)
@@ -1348,7 +1349,8 @@ def fwd_acceleration(m: Model, d: Data, factorize: bool = False):
 @event_scope
 def forward(m: Model, d: Data):
   """Forward dynamics."""
-  if not (m.opt.disableflags & DisableBit.ISLAND) and (m.opt.enableflags & EnableBit.SLEEP):
+  sleep_enabled = (d.nvmax < m.nv) or (not (m.opt.disableflags & DisableBit.ISLAND) and (m.opt.enableflags & EnableBit.SLEEP))
+  if sleep_enabled:
     sleep.wake(m, d)
     sleep.update_sleep(m, d)
 
@@ -1376,10 +1378,7 @@ def forward(m: Model, d: Data):
   fwd_actuation(m, d)
   fwd_acceleration(m, d, factorize=True)
 
-  if m.opt.nv_compact:
-    nvmax.solve_compact(m, d, nvmax.get_context(m, d))
-  else:
-    solver.solve(m, d)
+  solver.solve(m, d)
   sensor.sensor_acc(m, d)
 
 

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -24,6 +24,7 @@ import warp as wp
 from mujoco_warp._src import bvh
 from mujoco_warp._src import math as mjmath
 from mujoco_warp._src import render_util
+from mujoco_warp._src import sleep
 from mujoco_warp._src import smooth
 from mujoco_warp._src import types
 from mujoco_warp._src import warp_util
@@ -35,10 +36,6 @@ from mujoco_warp._src.util_pkg import check_version
 
 # TODO(team): remove after improving island solver performance
 ENABLE_ISLANDS = False
-
-# experimental: compact active DOFs into nv_max-sized arrays for factor/solve
-# override by setting io.ENABLE_NV_COMPACT = True
-ENABLE_NV_COMPACT = False
 
 
 def _is_array_spec(typ) -> bool:
@@ -268,7 +265,6 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
   opt.broadphase_filter = types.BroadphaseFilter.PLANE | types.BroadphaseFilter.SPHERE | types.BroadphaseFilter.OBB
   opt.graph_conditional = True
   opt.run_collision_detection = True
-  opt.nv_compact = ENABLE_NV_COMPACT
   contact_sensor_maxmatch_id = mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_NUMERIC, "contact_sensor_maxmatch")
   if contact_sensor_maxmatch_id > -1:
     opt.contact_sensor_maxmatch = mjm.numeric_data[mjm.numeric_adr[contact_sensor_maxmatch_id]]
@@ -1052,26 +1048,21 @@ def _allocate_island_arrays(
   d.iqfrc_constraint = wp.empty((nworld, nv_size), dtype=float)
 
 
-def _tree_actuated_mask(mjm: mujoco.MjModel) -> np.ndarray:
-  """Trees that contain an actuator (always-active seeds for nv_compact)."""
-  mask = np.zeros(mjm.ntree, dtype=bool)
-  for i in range(mjm.nu):
-    trntype = mjm.actuator_trntype[i]
-    # PoC: only joint transmissions are mapped to trees; other types wake via contact/force.
-    if trntype in (mujoco.mjtTrn.mjTRN_JOINT, mujoco.mjtTrn.mjTRN_JOINTINPARENT):
-      tree = mjm.dof_treeid[mjm.jnt_dofadr[mjm.actuator_trnid[i, 0]]]
-      if tree >= 0:
-        mask[tree] = True
-  return mask
-
-
-def _init_nv_compact(mjm: mujoco.MjModel, d: types.Data, nworld: int):
-  """Seed the persistent active-tree mask and clear the compaction maps."""
-  tree_actuated = _tree_actuated_mask(mjm)
-  d.tree_active = wp.array(np.tile(tree_actuated, (nworld, 1)), shape=(nworld, mjm.ntree), dtype=bool)
-  d.ncdof.zero_()
-  d.dof_cdof.fill_(-1)
-  d.cdof_dof.fill_(-1)
+def _initial_body_awake(mjm: mujoco.MjModel, nworld: int, init_asleep: bool) -> np.ndarray:
+  """Returns the initial body awake array."""
+  body_awake_np = np.zeros((nworld, mjm.nbody), dtype=np.int32)
+  for b in range(mjm.nbody):
+    tree = mjm.body_treeid[b]
+    if tree < 0:
+      root = mjm.body_rootid[b]
+      mocap = mjm.body_mocapid[root]
+      if mocap >= 0:
+        body_awake_np[:, b] = int(types.SleepState.AWAKE)
+      else:
+        body_awake_np[:, b] = int(types.SleepState.STATIC)
+    else:
+      body_awake_np[:, b] = int(types.SleepState.ASLEEP) if init_asleep else int(types.SleepState.AWAKE)
+  return body_awake_np
 
 
 def make_data(
@@ -1083,7 +1074,7 @@ def make_data(
   njmax_nnz: Optional[int] = None,
   naconmax: Optional[int] = None,
   naccdmax: Optional[int] = None,
-  nv_max: Optional[int] = None,
+  nvmax: Optional[int] = None,
 ) -> types.Data:
   """Creates a data object on device.
 
@@ -1098,7 +1089,7 @@ def make_data(
     njmax_nnz: Number of non-zeros in constraint Jacobian (sparse). Defaults to njmax * nv.
     naconmax: Number of contacts to allocate for all worlds. Overrides nconmax.
     naccdmax: Maximum number of CCD contacts. Defaults to naconmax.
-    nv_max: Capacity for compacted active DOFs per world (nv_compact). Defaults to nv.
+    nvmax: Capacity for compacted active DOFs per world. Defaults to nv.
 
   Returns:
     The data object containing the current state and output arrays (device).
@@ -1110,8 +1101,8 @@ def make_data(
   if njmax is None:
     njmax = _default_njmax(mjm)
 
-  if nv_max is None:
-    nv_max = mjm.nv
+  if nvmax is None:
+    nvmax = mjm.nv
 
   if nconmax < 0:
     raise ValueError("nconmax must be >= 0")
@@ -1119,8 +1110,8 @@ def make_data(
   if njmax < 0:
     raise ValueError("njmax must be >= 0")
 
-  if nv_max < 0 or nv_max > mjm.nv:
-    raise ValueError(f"nv_max ({nv_max}) must be in [0, nv ({mjm.nv})]")
+  if nvmax < 0 or nvmax > mjm.nv:
+    raise ValueError(f"nvmax ({nvmax}) must be in [0, nv ({mjm.nv})]")
 
   if nworld < 1:
     raise ValueError(f"nworld must be >= 1")
@@ -1143,6 +1134,9 @@ def make_data(
     elif nccdmax > nconmax:
       raise ValueError(f"nccdmax ({nccdmax}) must be <= nconmax ({nconmax})")
 
+  nv_compact = nvmax < mjm.nv
+  island_enabled = nv_compact or ENABLE_ISLANDS
+
   sizes = dict({"*": 1}, **{f.name: getattr(mjm, f.name, None) for f in dataclasses.fields(types.Model) if f.type is int})
   condim_arrays = [np.array([0]), mjm.geom_condim, mjm.pair_dim]
   if mjm.nflex > 0:
@@ -1154,7 +1148,7 @@ def make_data(
   sizes["nworld"] = nworld
   sizes["naconmax"] = naconmax
   sizes["njmax"] = njmax
-  sizes["nv_max"] = nv_max
+  sizes["nvmax"] = nvmax
 
   if njmax_nnz is None:
     if is_sparse(mjm):
@@ -1165,7 +1159,7 @@ def make_data(
   contact = types.Contact(**{f.name: _create_array(None, f.type, sizes) for f in dataclasses.fields(types.Contact)})
   contact.efc_address = wp.array(np.full((naconmax, sizes["nmaxpyramid"]), -1, dtype=int), dtype=int)
 
-  efc = _create_constraint(mjm, nworld, njmax, njmax_nnz, sizes, ENABLE_ISLANDS)
+  efc = _create_constraint(mjm, nworld, njmax, njmax_nnz, sizes, island_enabled)
 
   if is_sparse(mjm):
     efc.J_rownnz = wp.zeros((nworld, njmax), dtype=int)
@@ -1201,7 +1195,7 @@ def make_data(
     "naconmax": naconmax,
     "naccdmax": naccdmax,
     "njmax": njmax,
-    "nv_max": nv_max,
+    "nvmax": nvmax,
     "njmax_pad": sizes["njmax_pad"],
     "njmax_nnz": njmax_nnz,
     "M": None,
@@ -1242,10 +1236,14 @@ def make_data(
     "iqacc_smooth": None,
     "iqfrc_smooth": None,
     "iqfrc_constraint": None,
-    # sleep state: all trees start fully awake
-    "tree_asleep": wp.array(np.full((nworld, mjm.ntree), -(1 + types.MJ_MINAWAKE)), dtype=int),
-    "tree_awake": wp.array(np.ones((nworld, mjm.ntree)), dtype=int),
-    "body_awake": wp.array(np.ones((nworld, mjm.nbody)), dtype=int),
+    "tree_asleep": wp.array(
+      np.tile(np.arange(mjm.ntree, dtype=np.int32), (nworld, 1))
+      if nv_compact
+      else np.full((nworld, mjm.ntree), -(1 + types.MJ_MINAWAKE)),
+      dtype=int,
+    ),
+    "tree_awake": wp.array(np.zeros((nworld, mjm.ntree)) if nv_compact else np.ones((nworld, mjm.ntree)), dtype=int),
+    "body_awake": wp.array(_initial_body_awake(mjm, nworld, nv_compact), dtype=int),
   }
   for f in dataclasses.fields(types.Data):
     if f.name in d_kwargs:
@@ -1261,8 +1259,10 @@ def make_data(
     d.M = wp.zeros((nworld, sizes["nv_pad"], sizes["nv_pad"]), dtype=float)
     d.qLD = wp.zeros((nworld, mjm.nv, mjm.nv), dtype=float)
 
-  _allocate_island_arrays(mjm, d, nworld, njmax, ENABLE_ISLANDS, mjd)
-  _init_nv_compact(mjm, d, nworld)
+  _allocate_island_arrays(mjm, d, nworld, njmax, island_enabled, mjd)
+  d.ncdof.zero_()
+  d.dof_cdof.fill_(-1)
+  d.cdof_dof.fill_(-1)
 
   return d
 
@@ -1277,7 +1277,7 @@ def put_data(
   njmax_nnz: Optional[int] = None,
   naconmax: Optional[int] = None,
   naccdmax: Optional[int] = None,
-  nv_max: Optional[int] = None,
+  nvmax: Optional[int] = None,
 ) -> types.Data:
   """Moves data from host to a device.
 
@@ -1293,7 +1293,7 @@ def put_data(
     njmax_nnz: Number of non-zeros in constraint Jacobian (sparse). Defaults to njmax * nv.
     naconmax: Number of contacts to allocate for all worlds. Overrides nconmax.
     naccdmax: Maximum number of CCD contacts. Defaults to naconmax.
-    nv_max: Capacity for compacted active DOFs per world (nv_compact). Defaults to nv.
+    nvmax: Capacity for compacted active DOFs per world. Defaults to nv.
 
   Returns:
     The data object containing the current state and output arrays (device).
@@ -1308,8 +1308,8 @@ def put_data(
   if njmax is None:
     njmax = _default_njmax(mjm, mjd)
 
-  if nv_max is None:
-    nv_max = mjm.nv
+  if nvmax is None:
+    nvmax = mjm.nv
 
   if nconmax < 0:
     raise ValueError("nconmax must be >= 0")
@@ -1317,8 +1317,8 @@ def put_data(
   if njmax < 0:
     raise ValueError("njmax must be >= 0")
 
-  if nv_max < 0 or nv_max > mjm.nv:
-    raise ValueError(f"nv_max ({nv_max}) must be in [0, nv ({mjm.nv})]")
+  if nvmax < 0 or nvmax > mjm.nv:
+    raise ValueError(f"nvmax ({nvmax}) must be in [0, nv ({mjm.nv})]")
 
   if nworld < 1:
     raise ValueError(f"nworld must be >= 1")
@@ -1351,6 +1351,9 @@ def put_data(
   if mjd.nefc > njmax:
     raise ValueError(f"njmax overflow (njmax must be >= {mjd.nefc})")
 
+  nv_compact = nvmax < mjm.nv
+  island_enabled = nv_compact or ENABLE_ISLANDS
+
   sizes = dict({"*": 1}, **{f.name: getattr(mjm, f.name, None) for f in dataclasses.fields(types.Model) if f.type is int})
   condim_arrays = [np.array([0]), mjm.geom_condim, mjm.pair_dim]
   if mjm.nflex > 0:
@@ -1362,7 +1365,7 @@ def put_data(
   sizes["nworld"] = nworld
   sizes["naconmax"] = naconmax
   sizes["njmax"] = njmax
-  sizes["nv_max"] = nv_max
+  sizes["nvmax"] = nvmax
 
   if njmax_nnz is None:
     if is_sparse(mjm):
@@ -1406,7 +1409,7 @@ def put_data(
   # create efc
   efc_kwargs = {"J_rownnz": None, "J_rowadr": None, "J_colind": None, "J": None}
 
-  efc = _create_constraint(mjm, nworld, njmax, njmax_nnz, sizes, ENABLE_ISLANDS, mjd)
+  efc = _create_constraint(mjm, nworld, njmax, njmax_nnz, sizes, island_enabled, mjd)
 
   if is_sparse(mjm):
     J_rownnz = np.zeros(njmax, dtype=np.int32)
@@ -1453,7 +1456,7 @@ def put_data(
     "naconmax": naconmax,
     "naccdmax": naccdmax,
     "njmax": njmax,
-    "nv_max": nv_max,
+    "nvmax": nvmax,
     "njmax_pad": sizes["njmax_pad"],
     "njmax_nnz": njmax_nnz,
     # fields set after initialization:
@@ -1483,6 +1486,14 @@ def put_data(
     "iqacc_smooth": None,
     "iqfrc_smooth": None,
     "iqfrc_constraint": None,
+    "tree_asleep": wp.array(
+      np.tile(np.arange(mjm.ntree, dtype=np.int32), (nworld, 1))
+      if nv_compact
+      else np.full((nworld, mjm.ntree), -(1 + types.MJ_MINAWAKE)),
+      dtype=int,
+    ),
+    "tree_awake": wp.array(np.zeros((nworld, mjm.ntree)) if nv_compact else np.ones((nworld, mjm.ntree)), dtype=int),
+    "body_awake": wp.array(_initial_body_awake(mjm, nworld, nv_compact), dtype=int),
   }
   for f in dataclasses.fields(types.Data):
     if f.name in d_kwargs:
@@ -1515,8 +1526,10 @@ def put_data(
     d.M = wp.array(np.full((nworld, sizes["nv_pad"], sizes["nv_pad"]), M_padded), dtype=float)
     d.qLD = wp.array(np.full((nworld, mjm.nv, mjm.nv), qLD), dtype=float)
 
-  _allocate_island_arrays(mjm, d, nworld, njmax, ENABLE_ISLANDS, mjd)
-  _init_nv_compact(mjm, d, nworld)
+  _allocate_island_arrays(mjm, d, nworld, njmax, island_enabled, mjd)
+  d.ncdof.zero_()
+  d.dof_cdof.fill_(-1)
+  d.cdof_dof.fill_(-1)
 
   d.nacon = wp.array([mjd.ncon * nworld], dtype=int)
 
@@ -1809,6 +1822,9 @@ def reset_data(m: types.Model, d: types.Data, reset: Optional[wp.array] = None):
     d: The data object containing the current state and output arrays (device).
     reset: Per-world bitmask. Reset if True.
   """
+  sleep_enabled = (d.nvmax < m.nv) or (
+    not (m.opt.disableflags & types.DisableBit.ISLAND) and (m.opt.enableflags & types.EnableBit.SLEEP)
+  )
 
   @wp.kernel(module="unique", enable_backward=False)
   def reset_xfrc_applied(reset_in: wp.array[bool], xfrc_applied_out: wp.array2d[wp.spatial_vector]):
@@ -1994,6 +2010,7 @@ def reset_data(m: types.Model, d: types.Data, reset: Optional[wp.array] = None):
     body_treeid: wp.array[int],
     # In:
     mj_minawake: int,
+    sleep_enabled: int,
     reset_in: wp.array[bool],
     # Data out:
     tree_asleep_out: wp.array2d[int],
@@ -2009,8 +2026,12 @@ def reset_data(m: types.Model, d: types.Data, reset: Optional[wp.array] = None):
         return
 
     if elemid < ntree:
-      tree_asleep_out[worldid, elemid] = -(1 + mj_minawake)
-      tree_awake_out[worldid, elemid] = 1
+      if sleep_enabled == 1:
+        tree_asleep_out[worldid, elemid] = elemid
+        tree_awake_out[worldid, elemid] = 0
+      else:
+        tree_asleep_out[worldid, elemid] = -(1 + mj_minawake)
+        tree_awake_out[worldid, elemid] = 1
 
     if elemid < nbody:
       if body_treeid[elemid] < 0:
@@ -2019,7 +2040,10 @@ def reset_data(m: types.Model, d: types.Data, reset: Optional[wp.array] = None):
         else:
           body_awake_out[worldid, elemid] = int(types.SleepState.STATIC)
       else:
-        body_awake_out[worldid, elemid] = int(types.SleepState.AWAKE)
+        if sleep_enabled == 1:
+          body_awake_out[worldid, elemid] = int(types.SleepState.ASLEEP)
+        else:
+          body_awake_out[worldid, elemid] = int(types.SleepState.AWAKE)
       body_awake_ind_out[worldid, elemid] = elemid
 
     if elemid < nv:
@@ -2071,7 +2095,7 @@ def reset_data(m: types.Model, d: types.Data, reset: Optional[wp.array] = None):
   wp.launch(
     reset_sleep,
     dim=(d.nworld, max(m.ntree, m.nbody, m.nv)),
-    inputs=[m.nv, m.nbody, m.ntree, m.body_mocapid, m.body_treeid, types.MJ_MINAWAKE, reset_input],
+    inputs=[m.nv, m.nbody, m.ntree, m.body_mocapid, m.body_treeid, types.MJ_MINAWAKE, int(sleep_enabled), reset_input],
     outputs=[
       d.tree_asleep,
       d.tree_awake,
@@ -2109,6 +2133,9 @@ def reset_data(m: types.Model, d: types.Data, reset: Optional[wp.array] = None):
       d.nacon,
     ],
   )
+
+  if sleep_enabled:
+    sleep.update_sleep(m, d)
 
 
 # kernel_analyzer: off

--- a/mujoco_warp/_src/nvmax.py
+++ b/mujoco_warp/_src/nvmax.py
@@ -12,19 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Experimental: compact active DOFs into nv_max-sized arrays for factor/solve.
+"""Experimental: compact active DOFs into nvmax-sized arrays for factor/solve.
 
 The active set is tracked per kinematic tree (the unit of coupling in the mass
 matrix). A tree becomes active through an actuator (seeded at make_data), an
 applied force, or a contact, and stays active (monotonic - no deactivation yet).
 Each step the active trees' DOFs are packed into a contiguous [0, ncdof) range
-so the dense factor/solver can run at size nv_max instead of nv.
+so the dense factor/solver can run at size nvmax instead of nv.
 """
 
 import dataclasses
 
 import warp as wp
 
+from mujoco_warp._src import solver
+from mujoco_warp._src import support
 from mujoco_warp._src import types
 from mujoco_warp._src.block_cholesky import create_blocked_cholesky_factorize_solve_func
 from mujoco_warp._src.warp_util import cache_kernel
@@ -32,93 +34,26 @@ from mujoco_warp._src.warp_util import event_scope
 
 _TILE_SIZE = types.TILE_SIZE_JTDAJ_DENSE
 
-# A contact only wakes a sleeping tree if one of its bodies moves faster than this
-# (squared spatial velocity, |cvel|^2). Keeps settled/resting contacts asleep.
-_WAKE_SPEED_SQ = 1.0e-4
-
 
 def _round_up(x: int, multiple: int) -> int:
   return ((x + multiple - 1) // multiple) * multiple
 
 
 @wp.kernel
-def _seed_qfrc_applied(
+def _reset_compact_maps(
   # Model:
-  dof_treeid: wp.array[int],
+  nv: int,
   # Data in:
-  qfrc_applied_in: wp.array2d[float],
+  nvmax_in: int,
   # Data out:
-  tree_active_out: wp.array2d[bool],
+  dof_cdof_out: wp.array2d[int],
+  cdof_dof_out: wp.array2d[int],
 ):
-  worldid, dofid = wp.tid()
-  if qfrc_applied_in[worldid, dofid] != 0.0:
-    tree = dof_treeid[dofid]
-    if tree >= 0:
-      tree_active_out[worldid, tree] = True
-
-
-@wp.kernel
-def _seed_xfrc_applied(
-  # Model:
-  body_treeid: wp.array[int],
-  # Data in:
-  xfrc_applied_in: wp.array2d[wp.spatial_vector],
-  # Data out:
-  tree_active_out: wp.array2d[bool],
-):
-  worldid, bodyid = wp.tid()
-  tree = body_treeid[bodyid]
-  if tree < 0:
-    return
-  xfrc = xfrc_applied_in[worldid, bodyid]
-  for i in range(6):
-    if xfrc[i] != 0.0:
-      tree_active_out[worldid, tree] = True
-      return
-
-
-@wp.func
-def _body_moving(cvel_in: wp.array2d[wp.spatial_vector], worldid: int, bodyid: int, speed_sq: float) -> bool:
-  if bodyid < 0:
-    return False
-  v = cvel_in[worldid, bodyid]
-  return wp.dot(v, v) > speed_sq
-
-
-@wp.kernel
-def _seed_contacts(
-  # Model:
-  body_treeid: wp.array[int],
-  geom_bodyid: wp.array[int],
-  # Data in:
-  cvel_in: wp.array2d[wp.spatial_vector],
-  contact_geom_in: wp.array[wp.vec2i],
-  contact_worldid_in: wp.array[int],
-  nacon_in: wp.array[int],
-  # In:
-  wake_speed_sq: float,
-  # Data out:
-  tree_active_out: wp.array2d[bool],
-):
-  conid = wp.tid()
-  if conid >= nacon_in[0]:
-    return
-  worldid = contact_worldid_in[conid]
-  geom = contact_geom_in[conid]
-
-  b0 = wp.where(geom[0] >= 0, geom_bodyid[geom[0]], -1)
-  b1 = wp.where(geom[1] >= 0, geom_bodyid[geom[1]], -1)
-
-  # Velocity gate: only wake on contacts where at least one body is moving.
-  # Resting contacts (cup on a static table, settled clutter) stay asleep; motion
-  # propagates outward from the actuated/forced drivers over successive steps.
-  if not (_body_moving(cvel_in, worldid, b0, wake_speed_sq) or _body_moving(cvel_in, worldid, b1, wake_speed_sq)):
-    return
-
-  if b0 >= 0 and body_treeid[b0] >= 0:
-    tree_active_out[worldid, body_treeid[b0]] = True
-  if b1 >= 0 and body_treeid[b1] >= 0:
-    tree_active_out[worldid, body_treeid[b1]] = True
+  worldid, idx = wp.tid()
+  if idx < nv:
+    dof_cdof_out[worldid, idx] = -1
+  if idx < nvmax_in:
+    cdof_dof_out[worldid, idx] = -1
 
 
 @wp.kernel
@@ -128,8 +63,8 @@ def _compact_dofs(
   tree_dofadr: wp.array[int],
   tree_dofnum: wp.array[int],
   # Data in:
-  tree_active_in: wp.array2d[bool],
-  nv_max_in: int,
+  tree_awake_in: wp.array2d[int],
+  nvmax_in: int,
   # Data out:
   ncdof_out: wp.array[int],
   dof_cdof_out: wp.array2d[int],
@@ -138,49 +73,41 @@ def _compact_dofs(
   worldid = wp.tid()
   count = int(0)
   for t in range(ntree):
-    if tree_active_in[worldid, t]:
+    if tree_awake_in[worldid, t] == 1:
       adr = tree_dofadr[t]
       num = tree_dofnum[t]
       for j in range(num):
         dof = adr + j
-        if count < nv_max_in:
+        if count < nvmax_in:
           dof_cdof_out[worldid, dof] = count
           cdof_dof_out[worldid, count] = dof
         count += 1
 
-  if count > nv_max_in:
+  if count > nvmax_in:
     wp.printf(
-      "nv_compact overflow: world %d needs %d active DOFs but nv_max = %d (behavior undefined)\n",
+      "nvmax overflow: world %d needs %d active DOFs but nvmax = %d (behavior undefined)\n",
       worldid,
       count,
-      nv_max_in,
+      nvmax_in,
     )
-    ncdof_out[worldid] = nv_max_in
+    ncdof_out[worldid] = nvmax_in
   else:
     ncdof_out[worldid] = count
 
 
 @event_scope
 def update_active_dofs(m: types.Model, d: types.Data):
-  """Update the persistent active-tree mask and rebuild the compaction maps."""
-  # seed newly-active trees from applied forces and contacts (monotonic OR)
-  wp.launch(_seed_qfrc_applied, dim=(d.nworld, m.nv), inputs=[m.dof_treeid, d.qfrc_applied], outputs=[d.tree_active])
-  wp.launch(_seed_xfrc_applied, dim=(d.nworld, m.nbody), inputs=[m.body_treeid, d.xfrc_applied], outputs=[d.tree_active])
-
+  """Rebuild the compaction maps from tree_awake."""
   wp.launch(
-    _seed_contacts,
-    dim=(d.naconmax,),
-    inputs=[m.body_treeid, m.geom_bodyid, d.cvel, d.contact.geom, d.contact.worldid, d.nacon, _WAKE_SPEED_SQ],
-    outputs=[d.tree_active],
+    _reset_compact_maps,
+    dim=(d.nworld, m.nv),
+    inputs=[m.nv, d.nvmax],
+    outputs=[d.dof_cdof, d.cdof_dof],
   )
-
-  # rebuild compaction maps from the (monotonic) active-tree mask
-  d.dof_cdof.fill_(-1)
-  d.cdof_dof.fill_(-1)
   wp.launch(
     _compact_dofs,
     dim=(d.nworld,),
-    inputs=[m.ntree, m.tree_dofadr, m.tree_dofnum, d.tree_active, d.nv_max],
+    inputs=[m.ntree, m.tree_dofadr, m.tree_dofnum, d.tree_awake, d.nvmax],
     outputs=[d.ncdof, d.dof_cdof, d.cdof_dof],
   )
 
@@ -189,26 +116,26 @@ def update_active_dofs(m: types.Model, d: types.Data):
 class NvCompactContext:
   """Workspace for the compacted dense factor/solve.
 
-  DOF-space arrays are sized by nv_max_pad (nv_max rounded up to the dense tile size)
-  so the blocked Cholesky never reads out of bounds on its final partial block.
+  DOF-space arrays are sized by nvmax_pad (nvmax rounded up to the dense tile size)
+  so the blocked Cholesky never reads out of bounds on its partial block.
   """
 
-  nv_max_pad: int
-  # convergence tolerances rescaled by nv_full/nv_max_pad so the solver's nv-normalized
+  nvmax_pad: int
+  # convergence tolerances rescaled by nv_full/nvmax_pad so the solver's nv-normalized
   # done-test (solve.py: value/(meaninertia*nv)) matches the full-model baseline.
   tol_c: wp.array
   ls_tol_c: wp.array
-  # compacted dof-pair indices for the elliptic JTCJ Hessian (over nv_max_pad, not global nv)
+  # compacted dof-pair indices for the elliptic JTCJ Hessian (over nvmax_pad, not global nv)
   dof_tri_row_c: wp.array
   dof_tri_col_c: wp.array
   # smooth-solve workspace (Stage 2a)
-  M_c: wp.array3d[float]  # (nworld, nv_max_pad, nv_max_pad) compacted dense inertia
-  qLD_c: wp.array3d[float]  # (nworld, nv_max_pad, nv_max_pad) upper Cholesky factor
-  rhs_c: wp.array3d[float]  # (nworld, nv_max_pad, 1) compacted right-hand side
-  x_c: wp.array3d[float]  # (nworld, nv_max_pad, 1) compacted solution
+  M_c: wp.array3d[float]  # (nworld, nvmax_pad, nvmax_pad) compacted dense inertia
+  qLD_c: wp.array3d[float]  # (nworld, nvmax_pad, nvmax_pad) upper Cholesky factor
+  rhs_c: wp.array3d[float]  # (nworld, nvmax_pad, 1) compacted right-hand side
+  x_c: wp.array3d[float]  # (nworld, nvmax_pad, 1) compacted solution
   # constrained-solve workspace (Stage 2b): compacted views fed to the dense Newton solver
-  J_c: wp.array3d[float]  # (nworld, njmax_pad, nv_max_pad) compacted dense constraint Jacobian
-  Ma_c: wp.array2d[float]  # (nworld, nv_max_pad) M @ qacc workspace
+  J_c: wp.array3d[float]  # (nworld, njmax_pad, nvmax_pad) compacted dense constraint Jacobian
+  Ma_c: wp.array2d[float]  # (nworld, nvmax_pad) M @ qacc workspace
   qfrc_smooth_c: wp.array2d[float]
   qacc_smooth_c: wp.array2d[float]
   qacc_warmstart_c: wp.array2d[float]
@@ -217,14 +144,23 @@ class NvCompactContext:
 
 
 @wp.kernel
-def _scale_array(src: wp.array[float], scale: float, dst_out: wp.array[float]):
+def _scale_tolerances(
+  # In:
+  tolerance: wp.array[float],
+  ls_tolerance: wp.array[float],
+  scale: float,
+  # Out:
+  tol_out: wp.array[float],
+  ls_tol_out: wp.array[float],
+):
   i = wp.tid()
-  dst_out[i] = src[i] * scale
+  tol_out[i] = tolerance[i] * scale
+  ls_tol_out[i] = ls_tolerance[i] * scale
 
 
 @wp.kernel
 def _fill_dof_pairs(n: int, row_out: wp.array[int], col_out: wp.array[int]):
-  # Enumerate all (i, j) DOF pairs of the nv_max_pad-wide compacted Hessian. The elliptic
+  # Enumerate all (i, j) DOF pairs of the nvmax_pad-wide compacted Hessian. The elliptic
   # JTCJ correction indexes the Hessian via these; the global dof_tri (triu over full nv)
   # would write out of bounds. Pairs with a zero J_c column contribute nothing.
   i, j = wp.tid()
@@ -239,64 +175,67 @@ def get_context(m: types.Model, d: types.Data) -> NvCompactContext:
   and reused across steps.
   """
   ctx = getattr(d, "_nvcompact_ctx", None)
-  if ctx is None or ctx.nv_max_pad != _round_up(max(d.nv_max, 1), _TILE_SIZE):
+  if ctx is None or ctx.nvmax_pad != _round_up(max(d.nvmax, 1), _TILE_SIZE):
     ctx = create_nvcompact_context(m, d)
     d._nvcompact_ctx = ctx
   return ctx
 
 
 def create_nvcompact_context(m: types.Model, d: types.Data) -> NvCompactContext:
-  nv_max_pad = _round_up(max(d.nv_max, 1), _TILE_SIZE)
+  nvmax_pad = _round_up(max(d.nvmax, 1), _TILE_SIZE)
   nworld = d.nworld
 
-  def zeros2d():
-    return wp.zeros((nworld, nv_max_pad), dtype=float)
-
-  # match baseline's nv-normalized convergence test: the compact solve passes nv=nv_max_pad
+  # match baseline's nv-normalized convergence test: the compact solve passes nv=nvmax_pad
   # (< full nv) to the rescale, making it stricter; scale tolerance up to compensate.
   # Done on-device (no host sync) so context creation is safe inside CUDA graph capture.
-  tol_scale = float(m.nv) / float(nv_max_pad)
+  tol_scale = float(m.nv) / float(nvmax_pad)
   tol_c = wp.empty_like(m.opt.tolerance)
   ls_tol_c = wp.empty_like(m.opt.ls_tolerance)
-  wp.launch(_scale_array, dim=tol_c.shape[0], inputs=[m.opt.tolerance, tol_scale], outputs=[tol_c])
-  wp.launch(_scale_array, dim=ls_tol_c.shape[0], inputs=[m.opt.ls_tolerance, tol_scale], outputs=[ls_tol_c])
+  wp.launch(
+    _scale_tolerances,
+    dim=tol_c.shape[0],
+    inputs=[m.opt.tolerance, m.opt.ls_tolerance, tol_scale],
+    outputs=[tol_c, ls_tol_c],
+  )
 
   # compacted dof-pair indices for the elliptic JTCJ Hessian (built on-device, capture-safe)
-  npair = nv_max_pad * nv_max_pad
+  npair = nvmax_pad * nvmax_pad
   dof_tri_row_c = wp.empty(npair, dtype=int)
   dof_tri_col_c = wp.empty(npair, dtype=int)
-  wp.launch(_fill_dof_pairs, dim=(nv_max_pad, nv_max_pad), inputs=[nv_max_pad], outputs=[dof_tri_row_c, dof_tri_col_c])
+  wp.launch(_fill_dof_pairs, dim=(nvmax_pad, nvmax_pad), inputs=[nvmax_pad], outputs=[dof_tri_row_c, dof_tri_col_c])
 
   return NvCompactContext(
-    nv_max_pad=nv_max_pad,
+    nvmax_pad=nvmax_pad,
     tol_c=tol_c,
     ls_tol_c=ls_tol_c,
     dof_tri_row_c=dof_tri_row_c,
     dof_tri_col_c=dof_tri_col_c,
-    M_c=wp.zeros((nworld, nv_max_pad, nv_max_pad), dtype=float),
-    qLD_c=wp.zeros((nworld, nv_max_pad, nv_max_pad), dtype=float),
-    rhs_c=wp.zeros((nworld, nv_max_pad, 1), dtype=float),
-    x_c=wp.zeros((nworld, nv_max_pad, 1), dtype=float),
-    J_c=wp.zeros((nworld, d.njmax_pad, nv_max_pad), dtype=float),
-    Ma_c=zeros2d(),
-    qfrc_smooth_c=zeros2d(),
-    qacc_smooth_c=zeros2d(),
-    qacc_warmstart_c=zeros2d(),
-    qacc_c=zeros2d(),
-    qfrc_constraint_c=zeros2d(),
+    M_c=wp.empty((nworld, nvmax_pad, nvmax_pad), dtype=float),
+    qLD_c=wp.empty((nworld, nvmax_pad, nvmax_pad), dtype=float),
+    rhs_c=wp.empty((nworld, nvmax_pad, 1), dtype=float),
+    x_c=wp.empty((nworld, nvmax_pad, 1), dtype=float),
+    J_c=wp.empty((nworld, d.njmax_pad, nvmax_pad), dtype=float),
+    Ma_c=wp.empty((nworld, nvmax_pad), dtype=float),
+    qfrc_smooth_c=wp.empty((nworld, nvmax_pad), dtype=float),
+    qacc_smooth_c=wp.empty((nworld, nvmax_pad), dtype=float),
+    qacc_warmstart_c=wp.empty((nworld, nvmax_pad), dtype=float),
+    qacc_c=wp.empty((nworld, nvmax_pad), dtype=float),
+    qfrc_constraint_c=wp.empty((nworld, nvmax_pad), dtype=float),
   )
 
 
 @wp.kernel
-def _pad_identity(
+def _init_compact_inertia(
   # Data in:
   ncdof_in: wp.array[int],
   # Out:
   M_c_out: wp.array3d[float],
 ):
-  worldid, ci = wp.tid()
-  if ci >= ncdof_in[worldid]:
-    M_c_out[worldid, ci, ci] = 1.0
+  worldid, i, j = wp.tid()
+  val = 0.0
+  if i == j and i >= ncdof_in[worldid]:
+    val = 1.0
+  M_c_out[worldid, i, j] = val
 
 
 @wp.kernel
@@ -326,18 +265,40 @@ def _gather_M_sparse(
 
 
 @wp.kernel
-def _gather_rhs(
+def _gather_M_dense(
   # Data in:
+  M_in: wp.array3d[float],
   dof_cdof_in: wp.array2d[int],
+  # Out:
+  M_c_out: wp.array3d[float],
+):
+  worldid, i = wp.tid()
+  ci = dof_cdof_in[worldid, i]
+  if ci < 0:
+    return
+  nv = dof_cdof_in.shape[1]
+  for j in range(nv):
+    cj = dof_cdof_in[worldid, j]
+    if cj >= 0:
+      val = M_in[worldid, i, j]
+      M_c_out[worldid, ci, cj] = val
+
+
+@wp.kernel
+def _gather_rhs_compact(
+  # Data in:
+  cdof_dof_in: wp.array2d[int],
   # In:
   vec_in: wp.array2d[float],
   # Out:
   rhs_out: wp.array3d[float],
 ):
-  worldid, i = wp.tid()
-  ci = dof_cdof_in[worldid, i]
-  if ci >= 0:
-    rhs_out[worldid, ci, 0] = vec_in[worldid, i]
+  worldid, ci = wp.tid()
+  dof = cdof_dof_in[worldid, ci]
+  if dof >= 0:
+    rhs_out[worldid, ci, 0] = vec_in[worldid, dof]
+  else:
+    rhs_out[worldid, ci, 0] = 0.0
 
 
 @wp.kernel
@@ -384,20 +345,28 @@ def smooth_solve_compact(m: types.Model, d: types.Data, ctx: NvCompactContext):
 
   Inactive DOFs are frozen (qacc_smooth set to 0). Reads the sparse Model inertia.
   """
-  ctx.M_c.zero_()
-  ctx.rhs_c.zero_()
-  wp.launch(_pad_identity, dim=(d.nworld, ctx.nv_max_pad), inputs=[d.ncdof], outputs=[ctx.M_c])
+  wp.launch(
+    _init_compact_inertia,
+    dim=(d.nworld, ctx.nvmax_pad, ctx.nvmax_pad),
+    inputs=[d.ncdof],
+    outputs=[ctx.M_c],
+  )
   wp.launch(
     _gather_M_sparse,
     dim=(d.nworld, m.nv),
     inputs=[m.M_rownnz, m.M_rowadr, m.M_colind, d.M, d.dof_cdof],
     outputs=[ctx.M_c],
   )
-  wp.launch(_gather_rhs, dim=(d.nworld, m.nv), inputs=[d.dof_cdof, d.qfrc_smooth], outputs=[ctx.rhs_c])
+  wp.launch(
+    _gather_rhs_compact,
+    dim=(d.nworld, ctx.nvmax_pad),
+    inputs=[d.cdof_dof, d.qfrc_smooth],
+    outputs=[ctx.rhs_c],
+  )
   wp.launch_tiled(
-    _blocked_factor_solve(ctx.nv_max_pad),
+    _blocked_factor_solve(ctx.nvmax_pad),
     dim=d.nworld,
-    inputs=[ctx.M_c, ctx.rhs_c, ctx.nv_max_pad],
+    inputs=[ctx.M_c, ctx.rhs_c, ctx.nvmax_pad],
     outputs=[ctx.qLD_c, ctx.x_c],
     block_dim=m.block_dim.update_gradient_cholesky_blocked,
   )
@@ -405,35 +374,48 @@ def smooth_solve_compact(m: types.Model, d: types.Data, ctx: NvCompactContext):
 
 
 @wp.kernel
-def _gather_dof_vec(
+def _gather_dof_vecs_compact(
   # Data in:
-  dof_cdof_in: wp.array2d[int],
-  # In:
-  vec_in: wp.array2d[float],
+  qacc_warmstart_in: wp.array2d[float],
+  qfrc_smooth_in: wp.array2d[float],
+  qacc_smooth_in: wp.array2d[float],
+  cdof_dof_in: wp.array2d[int],
   # Out:
-  out: wp.array2d[float],
+  qfrc_smooth_c_out: wp.array2d[float],
+  qacc_smooth_c_out: wp.array2d[float],
+  qacc_warmstart_c_out: wp.array2d[float],
 ):
-  worldid, i = wp.tid()
-  ci = dof_cdof_in[worldid, i]
-  if ci >= 0:
-    out[worldid, ci] = vec_in[worldid, i]
+  worldid, ci = wp.tid()
+  dof = cdof_dof_in[worldid, ci]
+  if dof >= 0:
+    qfrc_smooth_c_out[worldid, ci] = qfrc_smooth_in[worldid, dof]
+    qacc_smooth_c_out[worldid, ci] = qacc_smooth_in[worldid, dof]
+    qacc_warmstart_c_out[worldid, ci] = qacc_warmstart_in[worldid, dof]
+  else:
+    qfrc_smooth_c_out[worldid, ci] = 0.0
+    qacc_smooth_c_out[worldid, ci] = 0.0
+    qacc_warmstart_c_out[worldid, ci] = 0.0
 
 
 @wp.kernel
-def _scatter_dof_vec(
+def _scatter_dof_vecs(
   # Data in:
   dof_cdof_in: wp.array2d[int],
   # In:
-  in_c: wp.array2d[float],
-  # Out:
-  out: wp.array2d[float],
+  qacc_c_in: wp.array2d[float],
+  qfrc_constraint_c_in: wp.array2d[float],
+  # Data out:
+  qacc_out: wp.array2d[float],
+  qfrc_constraint_out: wp.array2d[float],
 ):
   worldid, i = wp.tid()
   ci = dof_cdof_in[worldid, i]
   if ci >= 0:
-    out[worldid, i] = in_c[worldid, ci]
+    qacc_out[worldid, i] = qacc_c_in[worldid, ci]
+    qfrc_constraint_out[worldid, i] = qfrc_constraint_c_in[worldid, ci]
   else:
-    out[worldid, i] = 0.0  # frozen inactive DOF
+    qacc_out[worldid, i] = 0.0
+    qfrc_constraint_out[worldid, i] = 0.0
 
 
 @wp.kernel
@@ -460,9 +442,24 @@ def _gather_J_sparse(
       J_c_out[worldid, efcid, cj] = J_in[worldid, 0, adr]
 
 
-def _gather2d(d, src, dst):
-  dst.zero_()
-  wp.launch(_gather_dof_vec, dim=(d.nworld, src.shape[1]), inputs=[d.dof_cdof, src], outputs=[dst])
+@wp.kernel
+def _gather_J_dense(
+  # Data in:
+  nefc_in: wp.array[int],
+  dof_cdof_in: wp.array2d[int],
+  # In:
+  J_in: wp.array3d[float],
+  # Out:
+  J_c_out: wp.array3d[float],
+):
+  worldid, efcid = wp.tid()
+  if efcid >= nefc_in[worldid]:
+    return
+  nv = dof_cdof_in.shape[1]
+  for j in range(nv):
+    cj = dof_cdof_in[worldid, j]
+    if cj >= 0:
+      J_c_out[worldid, efcid, cj] = J_in[worldid, efcid, j]
 
 
 @event_scope
@@ -470,28 +467,24 @@ def solve_compact(m: types.Model, d: types.Data, ctx: NvCompactContext):
   """Run the dense Newton constraint solver in compacted DOF space.
 
   Gathers the active-DOF inertia, constraint Jacobian, and smooth/warmstart vectors
-  into nv_max_pad-sized dense workspaces, runs the stock dense Newton solver on a
-  shallow-replaced (m, d) at nv_max_pad, then scatters qacc/qfrc_constraint back.
+  into nvmax_pad-sized dense workspaces, runs the stock dense Newton solver on a
+  shallow-replaced (m, d) at nvmax_pad, then scatters qacc/qfrc_constraint back.
   Inactive DOFs are frozen to 0. Reads the sparse Model inertia and constraint J.
   """
-  import dataclasses as _dc
-
-  from mujoco_warp._src import solver
-
-  nvp = ctx.nv_max_pad
+  nvp = ctx.nvmax_pad
 
   _compact_gather(m, d, ctx)
 
-  # shallow-replace (m, d) so the stock dense Newton solver runs at nv_max_pad.
+  # shallow-replace (m, d) so the stock dense Newton solver runs at nvmax_pad.
   # Keep graph-conditional early-exit on CUDA (matches baseline: stops at convergence
   # instead of running all iterations); fall back to the plain loop on CPU.
   gc = m.opt.graph_conditional and wp.get_device().is_cuda
-  opt2 = _dc.replace(m.opt, graph_conditional=gc, tolerance=ctx.tol_c, ls_tolerance=ctx.ls_tol_c)
-  m2 = _dc.replace(
+  opt2 = dataclasses.replace(m.opt, graph_conditional=gc, tolerance=ctx.tol_c, ls_tolerance=ctx.ls_tol_c)
+  m2 = dataclasses.replace(
     m, opt=opt2, nv=nvp, nv_pad=nvp, is_sparse=False, dof_tri_row=ctx.dof_tri_row_c, dof_tri_col=ctx.dof_tri_col_c
   )
-  efc2 = _dc.replace(d.efc, J=ctx.J_c, Ma=ctx.Ma_c)
-  d2 = _dc.replace(
+  efc2 = dataclasses.replace(d.efc, J=ctx.J_c, Ma=ctx.Ma_c)
+  d2 = dataclasses.replace(
     d,
     M=ctx.M_c,
     qfrc_smooth=ctx.qfrc_smooth_c,
@@ -510,37 +503,72 @@ def solve_compact(m: types.Model, d: types.Data, ctx: NvCompactContext):
 
 @event_scope
 def _compact_gather(m: types.Model, d: types.Data, ctx: NvCompactContext):
-  nvp = ctx.nv_max_pad
+  nvp = ctx.nvmax_pad
   # gather compacted dense inertia (identity-padded tail)
-  ctx.M_c.zero_()
-  wp.launch(_pad_identity, dim=(d.nworld, nvp), inputs=[d.ncdof], outputs=[ctx.M_c])
   wp.launch(
-    _gather_M_sparse,
-    dim=(d.nworld, m.nv),
-    inputs=[m.M_rownnz, m.M_rowadr, m.M_colind, d.M, d.dof_cdof],
+    _init_compact_inertia,
+    dim=(d.nworld, nvp, nvp),
+    inputs=[d.ncdof],
     outputs=[ctx.M_c],
   )
+
+  if m.is_sparse:
+    wp.launch(
+      _gather_M_sparse,
+      dim=(d.nworld, m.nv),
+      inputs=[m.M_rownnz, m.M_rowadr, m.M_colind, d.M, d.dof_cdof],
+      outputs=[ctx.M_c],
+    )
+  else:
+    wp.launch(
+      _gather_M_dense,
+      dim=(d.nworld, m.nv),
+      inputs=[d.M, d.dof_cdof],
+      outputs=[ctx.M_c],
+    )
   # gather compacted dense constraint Jacobian (active columns only)
   ctx.J_c.zero_()
+  if m.is_sparse:
+    wp.launch(
+      _gather_J_sparse,
+      dim=(d.nworld, d.njmax),
+      inputs=[d.nefc, d.dof_cdof, d.efc.J_rownnz, d.efc.J_rowadr, d.efc.J_colind, d.efc.J],
+      outputs=[ctx.J_c],
+    )
+  else:
+    wp.launch(
+      _gather_J_dense,
+      dim=(d.nworld, d.njmax),
+      inputs=[d.nefc, d.dof_cdof, d.efc.J],
+      outputs=[ctx.J_c],
+    )
+  # gather compacted DOF-space vectors in a single launch
   wp.launch(
-    _gather_J_sparse,
-    dim=(d.nworld, d.njmax),
-    inputs=[d.nefc, d.dof_cdof, d.efc.J_rownnz, d.efc.J_rowadr, d.efc.J_colind, d.efc.J],
-    outputs=[ctx.J_c],
+    _gather_dof_vecs_compact,
+    dim=(d.nworld, nvp),
+    inputs=[
+      d.qacc_warmstart,
+      d.qfrc_smooth,
+      d.qacc_smooth,
+      d.cdof_dof,
+    ],
+    outputs=[
+      ctx.qfrc_smooth_c,
+      ctx.qacc_smooth_c,
+      ctx.qacc_warmstart_c,
+    ],
   )
-  # gather compacted DOF-space vectors
-  _gather2d(d, d.qfrc_smooth, ctx.qfrc_smooth_c)
-  _gather2d(d, d.qacc_smooth, ctx.qacc_smooth_c)
-  _gather2d(d, d.qacc_warmstart, ctx.qacc_warmstart_c)
 
 
 @event_scope
 def _compact_scatter(m: types.Model, d: types.Data, ctx: NvCompactContext):
-  from mujoco_warp._src import support
-
-  # scatter results back to full DOF space (inactive frozen to 0)
-  wp.launch(_scatter_dof_vec, dim=(d.nworld, m.nv), inputs=[d.dof_cdof, ctx.qacc_c], outputs=[d.qacc])
-  wp.launch(_scatter_dof_vec, dim=(d.nworld, m.nv), inputs=[d.dof_cdof, ctx.qfrc_constraint_c], outputs=[d.qfrc_constraint])
+  # scatter results back to full DOF space (inactive frozen to 0) in one launch
+  wp.launch(
+    _scatter_dof_vecs,
+    dim=(d.nworld, m.nv),
+    inputs=[d.dof_cdof, ctx.qacc_c, ctx.qfrc_constraint_c],
+    outputs=[d.qacc, d.qfrc_constraint],
+  )
 
   # Refresh full d.efc.Ma = M @ qacc. The integrators (Euler/implicit damping) use Ma as
   # the RHS; the compact solve only populated the compacted Ma, so recompute it in full

--- a/mujoco_warp/_src/nvmax_test.py
+++ b/mujoco_warp/_src/nvmax_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-"""Tests for nv_compact active-DOF bookkeeping."""
+"""Tests for active-DOF bookkeeping."""
 
 import mujoco
 import numpy as np
@@ -21,7 +21,10 @@ import warp as wp
 from absl.testing import absltest
 
 import mujoco_warp as mjwarp
+from mujoco_warp import test_data
 from mujoco_warp._src import nvmax
+from mujoco_warp._src import sleep
+from mujoco_warp._src.sleep import K_AWAKE_VAL
 
 # An actuated 2-hinge arm (tree 0, dofs 0-1) plus two free bodies
 # (tree 1, dofs 2-7 and tree 2, dofs 8-13).
@@ -48,15 +51,6 @@ _XML = """
 """
 
 
-def _setup(nworld=1, nv_max=None, sparse=False):
-  mjm = mujoco.MjModel.from_xml_string(_XML)
-  if sparse:
-    mjm.opt.jacobian = mujoco.mjtJacobian.mjJAC_SPARSE
-  m = mjwarp.put_model(mjm)
-  d = mjwarp.make_data(mjm, nworld=nworld, nv_max=nv_max)
-  return mjm, m, d
-
-
 # Two free spheres resting (penetrating) on a floor, plus an actuated hinge arm.
 # Generates contacts so the constrained solver does real work.
 _CONTACT_XML = """
@@ -76,19 +70,11 @@ _CONTACT_XML = """
 """
 
 
-def _setup_contact(nv_max=None):
-  mjm = mujoco.MjModel.from_xml_string(_CONTACT_XML)
-  m = mjwarp.put_model(mjm)
-  d = mjwarp.make_data(mjm, nv_max=nv_max)
-  return mjm, m, d
-
-
 class NvCompactBookkeepingTest(absltest.TestCase):
   def test_actuated_tree_seeded(self):
     """Only the actuated arm tree is active at construction; maps are compact."""
-    _, m, d = _setup()
-    np.testing.assert_array_equal(d.tree_active.numpy()[0], [True, False, False])
-
+    _, _, m, d = test_data.fixture(xml=_XML)
+    d.tree_awake = wp.array([[1, 0, 0]], dtype=int)
     nvmax.update_active_dofs(m, d)
 
     self.assertEqual(d.ncdof.numpy()[0], 2)
@@ -100,14 +86,24 @@ class NvCompactBookkeepingTest(absltest.TestCase):
 
   def test_applied_force_wakes_tree_per_world(self):
     """qfrc_applied on a free-body DOF wakes its whole tree, independently per world."""
-    _, m, d = _setup(nworld=2)
+    _, _, m, d = test_data.fixture(xml=_XML, nworld=2)
+
+    # 1. Set all trees asleep initially
+    d.tree_awake.fill_(0)
+    d.tree_asleep.fill_(0)
+
+    # 2. Apply force to dof 2 (belongs to tree 1) in world 0
     qfrc = d.qfrc_applied.numpy()
-    qfrc[0, 2] = 1.0  # dof 2 belongs to tree 1 (first free body) in world 0
+    qfrc[0, 2] = 1.0
     d.qfrc_applied = wp.array(qfrc, dtype=float)
+
+    # 3. Run sleep.wake to wake up trees with forces
+    sleep.wake(m, d)
+    sleep.update_sleep(m, d)
 
     nvmax.update_active_dofs(m, d)
 
-    # world 0: arm (2) + free body (6) = 8; world 1: arm only = 2
+    # world 0: arm (2) + free body 1 (6) = 8; world 1: arm only = 2
     np.testing.assert_array_equal(d.ncdof.numpy(), [8, 2])
     np.testing.assert_array_equal(d.dof_cdof.numpy()[0][:8], np.arange(8))
     self.assertTrue((d.dof_cdof.numpy()[1][2:] == -1).all())
@@ -127,64 +123,75 @@ class NvCompactBookkeepingTest(absltest.TestCase):
 
   def test_moving_contact_wakes_both_trees(self):
     """A contact with a moving body activates the trees of both involved geoms."""
-    mjm, m, d = _setup()
+    mjm, _, m, d = test_data.fixture(xml=_XML)
     ball0 = mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_GEOM, "ball0")
     ball1 = mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_GEOM, "ball1")
+
+    # 1. Set tree 1 (ball0) awake initially, tree 0 and 2 asleep (pointing to themselves)
+    asleep = np.array([[0, K_AWAKE_VAL, 2]], dtype=np.int32)
+    d.tree_asleep = wp.array(asleep, dtype=int)
+    sleep.update_sleep(m, d)
 
     self._fake_contact(d, ball0, ball1)
-    self._set_body_moving(m, d, ball0)  # ball0 is moving into ball1
+
+    sleep.wake_collision(m, d)
+    sleep.update_sleep(m, d)
+
     nvmax.update_active_dofs(m, d)
 
-    # arm (seeded) + both free bodies = 2 + 6 + 6 = 14
-    np.testing.assert_array_equal(d.tree_active.numpy()[0], [True, True, True])
-    self.assertEqual(d.ncdof.numpy()[0], 14)
+    # both free bodies awake = 6 + 6 = 12 DOFs
+    self.assertEqual(d.ncdof.numpy()[0], 12)
 
   def test_resting_contact_does_not_wake(self):
-    """A contact where both bodies are at rest does not wake them (velocity gate)."""
-    mjm, m, d = _setup()
+    """A contact where both bodies are at rest does not wake them."""
+    mjm, _, m, d = test_data.fixture(xml=_XML)
     ball0 = mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_GEOM, "ball0")
     ball1 = mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_GEOM, "ball1")
 
-    self._fake_contact(d, ball0, ball1)  # both at rest (cvel = 0)
+    # 1. Set all trees asleep initially
+    asleep = np.array([[0, 1, 2]], dtype=np.int32)
+    d.tree_asleep = wp.array(asleep, dtype=int)
+    sleep.update_sleep(m, d)
+
+    self._fake_contact(d, ball0, ball1)
+
+    sleep.wake_collision(m, d)
+    sleep.update_sleep(m, d)
+
     nvmax.update_active_dofs(m, d)
 
-    # only the actuated arm stays active; the resting balls remain asleep
-    np.testing.assert_array_equal(d.tree_active.numpy()[0], [True, False, False])
-    self.assertEqual(d.ncdof.numpy()[0], 2)
+    # both stay asleep
+    self.assertEqual(d.ncdof.numpy()[0], 0)
 
   def test_static_geom_does_not_wake(self):
-    """A contact with a static (world) geom only wakes the moving dynamic side."""
-    mjm, m, d = _setup()
+    """A contact with a static (world) geom only wakes the dynamic side."""
+    mjm, _, m, d = test_data.fixture(xml=_XML)
     floor = mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_GEOM, "floor")
     ball0 = mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_GEOM, "ball0")
 
+    # 1. Set ball0 (tree 1) awake, tree 0 and 2 asleep
+    asleep = np.array([[0, K_AWAKE_VAL, 2]], dtype=np.int32)
+    d.tree_asleep = wp.array(asleep, dtype=int)
+    sleep.update_sleep(m, d)
+
     self._fake_contact(d, floor, ball0)
-    self._set_body_moving(m, d, ball0)  # ball0 dropping onto the floor
+
+    sleep.wake_collision(m, d)
+    sleep.update_sleep(m, d)
+
     nvmax.update_active_dofs(m, d)
 
-    # floor is static (tree -1): only ball0's tree wakes, alongside the arm.
-    np.testing.assert_array_equal(d.tree_active.numpy()[0], [True, True, False])
-    self.assertEqual(d.ncdof.numpy()[0], 8)
-
-  def test_monotonic(self):
-    """Once active, a tree stays active after the triggering force is removed."""
-    _, m, d = _setup()
-    qfrc = d.qfrc_applied.numpy()
-    qfrc[0, 8] = 1.0  # wake tree 2
-    d.qfrc_applied = wp.array(qfrc, dtype=float)
-    nvmax.update_active_dofs(m, d)
-    self.assertEqual(d.ncdof.numpy()[0], 8)
-
-    d.qfrc_applied = wp.array(np.zeros_like(qfrc), dtype=float)
-    nvmax.update_active_dofs(m, d)
-    self.assertEqual(d.ncdof.numpy()[0], 8)  # still active
+    # only tree 1 (ball0) wakes -> 6 DOFs
+    self.assertEqual(d.ncdof.numpy()[0], 6)
 
   def test_overflow_clamps_and_warns(self):
-    """When active DOFs exceed nv_max, ncdof is clamped to nv_max."""
-    _, m, d = _setup(nv_max=4)
-    ta = d.tree_active.numpy()
-    ta[0, :] = True
-    d.tree_active = wp.array(ta, dtype=bool)
+    """When active DOFs exceed nvmax, ncdof is clamped to nvmax."""
+    mjm = mujoco.MjModel.from_xml_string(_XML)
+    mjd = mujoco.MjData(mjm)
+    mujoco.mj_forward(mjm, mjd)
+    m = mjwarp.put_model(mjm)
+    d = mjwarp.put_data(mjm, mjd, nvmax=4)
+    d.tree_awake = wp.array([[1, 1, 1]], dtype=int)
 
     nvmax.update_active_dofs(m, d)
 
@@ -193,13 +200,13 @@ class NvCompactBookkeepingTest(absltest.TestCase):
 
 class NvCompactSmoothSolveTest(absltest.TestCase):
   def test_smooth_solve_equivalence_all_active(self):
-    """With every tree active and nv_max=nv, compacted qacc_smooth matches baseline."""
-    _, m, d = _setup(sparse=True)
+    """With every tree active and nvmax=nv, compacted qacc_smooth matches baseline."""
+    _, _, m, d = test_data.fixture(xml=_XML, overrides={"opt.jacobian": "SPARSE"})
     self.assertTrue(m.is_sparse)
     mjwarp.forward(m, d)
     baseline = d.qacc_smooth.numpy().copy()
 
-    d.tree_active = wp.array(np.ones((d.nworld, m.ntree), dtype=bool), dtype=bool)
+    d.tree_awake = wp.array(np.ones((d.nworld, m.ntree), dtype=int), dtype=int)
     nvmax.update_active_dofs(m, d)
     self.assertEqual(d.ncdof.numpy()[0], m.nv)
 
@@ -210,11 +217,12 @@ class NvCompactSmoothSolveTest(absltest.TestCase):
 
   def test_smooth_solve_partial_active_freezes_rest(self):
     """Active trees match baseline (M is block-diagonal); inactive DOFs are frozen to 0."""
-    _, m, d = _setup(sparse=True)
+    _, _, m, d = test_data.fixture(xml=_XML, overrides={"opt.jacobian": "SPARSE"})
     mjwarp.forward(m, d)
     baseline = d.qacc_smooth.numpy().copy()
 
     # only the actuated arm tree (dofs 0-1) is active
+    d.tree_awake = wp.array([[1, 0, 0]], dtype=int)
     nvmax.update_active_dofs(m, d)
     self.assertEqual(d.ncdof.numpy()[0], 2)
 
@@ -228,14 +236,14 @@ class NvCompactSmoothSolveTest(absltest.TestCase):
 
 class NvCompactConstrainedSolveTest(absltest.TestCase):
   def test_constrained_solve_equivalence_all_active(self):
-    """With every tree active and nv_max=nv, the compacted Newton solve matches baseline qacc."""
-    _, m, d = _setup_contact()
+    """With every tree active and nvmax=nv, the compacted Newton solve matches baseline qacc."""
+    _, _, m, d = test_data.fixture(xml=_CONTACT_XML)
     self.assertTrue(m.is_sparse)
     mjwarp.forward(m, d)  # full baseline solve (also builds efc.J, M)
     self.assertGreater(d.nacon.numpy()[0], 0)  # contacts exist
     baseline_qacc = d.qacc.numpy().copy()
 
-    d.tree_active = wp.array(np.ones((d.nworld, m.ntree), dtype=bool), dtype=bool)
+    d.tree_awake = wp.array(np.ones((d.nworld, m.ntree), dtype=int), dtype=int)
     nvmax.update_active_dofs(m, d)
     self.assertEqual(d.ncdof.numpy()[0], m.nv)
 
@@ -243,6 +251,32 @@ class NvCompactConstrainedSolveTest(absltest.TestCase):
     nvmax.solve_compact(m, d, ctx)
 
     np.testing.assert_allclose(d.qacc.numpy(), baseline_qacc, rtol=1e-3, atol=1e-4)
+
+  def test_solve_compact_populates_islands(self):
+    """When using the compact solver via mjwarp.solve, island mapping fields are updated."""
+    mjm = mujoco.MjModel.from_xml_string(_CONTACT_XML)
+    mjd = mujoco.MjData(mjm)
+    mujoco.mj_forward(mjm, mjd)
+    m = mjwarp.put_model(mjm)
+    # nv = 13. We set nvmax = 8 (which is < 13, so compact solver is triggered)
+    d = mjwarp.put_data(mjm, mjd, nvmax=8)
+
+    # Artificially set tree_island map on device
+    d.tree_island = wp.array([[2, 2, 2]], dtype=int)
+    d.nisland = wp.array([3], dtype=int)
+
+    # Run solver which triggers solve_compact
+    mjwarp.solve(m, d)
+
+    # Assert that d.dof_island and d.efc.island are updated based on the new tree_island
+    dof_island = d.dof_island.numpy()[0]
+    np.testing.assert_array_equal(dof_island, [2] * m.nv)
+
+    nefc = d.nefc.numpy()[0]
+    efc_island = d.efc.island.numpy()[0]
+    self.assertGreater(nefc, 0)
+    np.testing.assert_array_equal(efc_island[:nefc], [2] * nefc)
+    np.testing.assert_array_equal(efc_island[nefc:], [-1] * (d.njmax - nefc))
 
 
 if __name__ == "__main__":

--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -19,6 +19,7 @@ import warp as wp
 
 from mujoco_warp._src import island
 from mujoco_warp._src import math
+from mujoco_warp._src import nvmax
 from mujoco_warp._src import smooth
 from mujoco_warp._src import support
 from mujoco_warp._src import types
@@ -2513,6 +2514,8 @@ def _update_gradient_JTCJ_sparse(
       continue
 
     efcid0 = contact_efc_address_in[conid, 0]
+    if efcid0 < 0:
+      continue
     if efc_state_in[worldid, efcid0] != types.ConstraintState.CONE:
       continue
 
@@ -2550,7 +2553,10 @@ def _update_gradient_JTCJ_sparse(
     tt = float(0.0)
     for j in range(1, condim):
       efcidj = contact_efc_address_in[conid, j]
-      uj = ctx_Jaref_in[worldid, efcidj] * fri[j - 1]
+      if efcidj >= 0:
+        uj = ctx_Jaref_in[worldid, efcidj] * fri[j - 1]
+      else:
+        uj = 0.0
       tt += uj * uj
       u[j] = uj
 
@@ -2574,6 +2580,8 @@ def _update_gradient_JTCJ_sparse(
         dm_fri1 = dm * mu
       else:
         efcid1 = contact_efc_address_in[conid, dim1id]
+        if efcid1 < 0:
+          continue
         rowadr1 = efc_J_rowadr_in[worldid, efcid1]
         dm_fri1 = dm * fri[dim1id - 1]
 
@@ -2589,6 +2597,8 @@ def _update_gradient_JTCJ_sparse(
           dm_fri12 = dm_fri1 * mu
         else:
           efcid2 = contact_efc_address_in[conid, dim2id]
+          if efcid2 < 0:
+            continue
           rowadr2 = efc_J_rowadr_in[worldid, efcid2]
           dm_fri12 = dm_fri1 * fri[dim2id - 1]
 
@@ -2674,6 +2684,8 @@ def _update_gradient_JTCJ_compact(
       continue
 
     efcid0 = contact_efc_address_in[conid, 0]
+    if efcid0 < 0:
+      continue
     if efc_state_in[worldid, efcid0] != types.ConstraintState.CONE:
       continue
 
@@ -2718,7 +2730,10 @@ def _update_gradient_JTCJ_compact(
     tt = float(0.0)
     for j in range(1, condim):
       efcidj = contact_efc_address_in[conid, j]
-      uj = ctx_Jaref_in[worldid, efcidj] * fri[j - 1]
+      if efcidj >= 0:
+        uj = ctx_Jaref_in[worldid, efcidj] * fri[j - 1]
+      else:
+        uj = 0.0
       tt += uj * uj
       u[j] = uj
 
@@ -2742,6 +2757,8 @@ def _update_gradient_JTCJ_compact(
         dm_fri1 = dm * mu
       else:
         efcid1 = contact_efc_address_in[conid, dim1id]
+        if efcid1 < 0:
+          continue
         dm_fri1 = dm * fri[dim1id - 1]
 
       # Read from the compacted dense Jacobian (efc_J_in) using the mapped compacted DOFs
@@ -2756,6 +2773,8 @@ def _update_gradient_JTCJ_compact(
           dm_fri12 = dm_fri1 * mu
         else:
           efcid2 = contact_efc_address_in[conid, dim2id]
+          if efcid2 < 0:
+            continue
           dm_fri12 = dm_fri1 * fri[dim2id - 1]
 
         # Read from the compacted dense Jacobian using the mapped compacted DOFs
@@ -2841,6 +2860,8 @@ def _update_gradient_JTCJ_dense(
       continue
 
     efcid0 = contact_efc_address_in[conid, 0]
+    if efcid0 < 0:
+      continue
     if efc_state_in[worldid, efcid0] != types.ConstraintState.CONE:
       continue
 
@@ -2859,7 +2880,10 @@ def _update_gradient_JTCJ_dense(
     tt = float(0.0)
     for j in range(1, condim):
       efcidj = contact_efc_address_in[conid, j]
-      uj = ctx_Jaref_in[worldid, efcidj] * fri[j - 1]
+      if efcidj >= 0:
+        uj = ctx_Jaref_in[worldid, efcidj] * fri[j - 1]
+      else:
+        uj = 0.0
       tt += uj * uj
       u[j] = uj
 
@@ -2877,6 +2901,8 @@ def _update_gradient_JTCJ_dense(
         efcid1 = efcid0
       else:
         efcid1 = contact_efc_address_in[conid, dim1id]
+        if efcid1 < 0:
+          continue
 
       efc_J11 = efc_J_in[worldid, efcid1, dof1id]
       efc_J12 = efc_J_in[worldid, efcid1, dof2id]
@@ -2888,6 +2914,8 @@ def _update_gradient_JTCJ_dense(
           efcid2 = efcid0
         else:
           efcid2 = contact_efc_address_in[conid, dim2id]
+          if efcid2 < 0:
+            continue
 
         efc_J21 = efc_J_in[worldid, efcid2, dof1id]
         efc_J22 = efc_J_in[worldid, efcid2, dof2id]
@@ -3188,7 +3216,8 @@ def _update_gradient(m: types.Model, d: types.Data, ctx: SolverContext):
       # we don't over-launch naconmax (capacity) threads when active contacts are far fewer. The
       # sparse kernel uses one thread per (contact, support-pair) (jtcj_max_pairs), the dense one
       # per (contact, dof-pair) (dof_tri_row.size).
-      jtcj_second_dim = m.jtcj_max_pairs if (m.is_sparse or m.opt.nv_compact) else m.dof_tri_row.size
+      is_sparse_compact = (d.nvmax < m.nv) and (d.efc.J_colind.shape[1] > 0)
+      jtcj_second_dim = m.jtcj_max_pairs if (m.is_sparse or is_sparse_compact) else m.dof_tri_row.size
       if wp.get_device().is_cuda:
         sm_count = wp.get_device().sm_count
 
@@ -3231,7 +3260,7 @@ def _update_gradient(m: types.Model, d: types.Data, ctx: SolverContext):
           outputs=[ctx.h],
         )
       else:
-        if m.opt.nv_compact:
+        if is_sparse_compact:
           wp.launch(
             _update_gradient_JTCJ_compact,
             dim=(dim_block, m.jtcj_max_pairs),
@@ -3717,6 +3746,12 @@ def init_context(m: types.Model, d: types.Data, ctx: SolverContext | InverseCont
 
 @event_scope
 def solve(m: types.Model, d: types.Data):
+  if d.nvmax < m.nv:
+    nvmax.solve_compact(m, d, nvmax.get_context(m, d))
+    if m.ntree > 1:
+      island.compute_island_mapping(m, d, None)
+    return
+
   if d.njmax == 0 or m.nv == 0:
     wp.copy(d.qacc, d.qacc_smooth)
     d.solver_niter.fill_(0)

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -818,7 +818,6 @@ class Option:
       zeros out the contacts at each step)
     contact_sensor_maxmatch: max number of contacts considered by contact sensor matching criteria
                              contacts matched after this value is exceded will be ignored
-    nv_compact: experimental - compact active DOFs into nv_max-sized arrays for factor/solve
   """
 
   timestep: array("*", float)
@@ -850,7 +849,6 @@ class Option:
   graph_conditional: bool
   run_collision_detection: bool
   contact_sensor_maxmatch: int
-  nv_compact: bool
 
 
 @dataclasses.dataclass
@@ -2029,16 +2027,15 @@ class Data:
     iqfrc_smooth: island-local qfrc_smooth                      (nworld, nv)
     iqfrc_constraint: island-local qfrc_constraint              (nworld, nv)
     ncdof: number of active (compacted) DOFs per world          (nworld,)
-    tree_active: persistent active mask per tree                (nworld, ntree)
     dof_cdof: global DOF -> compacted DOF; -1 if inactive       (nworld, nv)
-    cdof_dof: compacted DOF -> global DOF; -1 if unused         (nworld, nv_max)
+    cdof_dof: compacted DOF -> global DOF; -1 if unused         (nworld, nvmax)
 
   warp only fields:
     nworld: number of worlds
     naconmax: maximum number of contacts (shared across all worlds)
     naccdmax: maximum number of contacts for CCD (all worlds)
     njmax: maximum number of constraints per world
-    nv_max: capacity for compacted active DOFs per world (nv_compact)
+    nvmax: capacity for compacted active DOFs per world
     njmax_pad: njmax rounded up to the nearest multiple of TILE_SIZE_JTDAJ
     njmax_nnz: number of non-zeros in constraint Jacobian
     nacon: number of detected contacts (across all worlds)      (1,)
@@ -2157,16 +2154,15 @@ class Data:
   iqfrc_smooth: wp.array2d[float]
   iqfrc_constraint: wp.array2d[float]
   ncdof: array("nworld", int)
-  tree_active: array("nworld", "ntree", bool)
   dof_cdof: array("nworld", "nv", int)
-  cdof_dof: array("nworld", "nv_max", int)
+  cdof_dof: array("nworld", "nvmax", int)
 
   # warp only fields:
   nworld: int
   naconmax: int
   naccdmax: int
   njmax: int
-  nv_max: int
+  nvmax: int
   njmax_pad: int
   njmax_nnz: int
   nacon: array(1, int)


### PR DESCRIPTION
integrates the compact solver with the island discovery + sleep/wake logic

enable by setting `nvmax` less than `nv`

---

the existing branch
```
mjwarp-testspeed /tmp/benchmark_assets/aloha_clutter/scene_clutter.xml   --nworld=512   --nconmax=512   --nccdmax=64   --njmax=1024 --nv_compact --nv_max=64 --replay=/tmp/benchmark_assets/aloha_clutter/pick_clutter.npz --event_trace
```

```
Summary for 512 parallel rollouts

Total JIT time: 0.75 s
Total simulation time: 12.16 s
Total steps per second: 115,865
Total realtime factor: 231.73 x
Total time per step: 8630.72 ns
Total converged worlds: 512 / 512

Event trace:

step: 8597.71
  forward: 8486.77
    sensor_vel: 2.80
    solve_compact: 3137.11
      _compact_gather: 329.33
      mul_m: 36.23
      _compact_scatter: 29.17
        mul_m: 15.13
    fwd_actuation: 20.32
    sensor_pos: 2.80
    fwd_velocity: 142.31
      passive: 16.26
      tendon_bias: 2.80
      rne: 65.78
      com_vel: 36.92
    sensor_acc: 18.85
    fwd_position: 4613.11
      collision: 4188.79
        convex_narrowphase: 3174.54
        nxn_broadphase: 972.72
        primitive_narrowphase: 24.42
      crb: 66.78
      kinematics: 89.45
      com_pos: 79.08
      transmission: 16.21
      make_constraint: 113.19
      camlight: 20.30
      tendon_armature: 2.79
      flex: 2.79
      tendon: 2.82
    fwd_acceleration: 522.09
      xfrc_accumulate: 19.99
      update_active_dofs: 48.94
      smooth_solve_compact: 103.48
  euler: 102.20
```

this commit
```
mjwarp-testspeed /tmp/benchmark_assets/aloha_clutter/scene_clutter.xml   --nworld=512   --nconmax=512   --nccdmax=64   --njmax=1024 --nvmax=64 --replay=/tmp/benchmark_assets/aloha_clutter/pick_clutter.npz --event_trace
```

```
Summary for 512 parallel rollouts

Total JIT time: 0.79 s
Total simulation time: 14.17 s
Total steps per second: 99,419
Total realtime factor: 198.84 x
Total time per step: 10058.42 ns
Total converged worlds: 512 / 512

Event trace:

step: 10024.91
  forward: 9608.01
    fwd_position: 5804.01
      kinematics: 86.70
      update_sleep: [ 22.23, 22.26 ]
      wake_collision: 10.31
      make_constraint: 112.67
      crb: 67.69
      tendon_armature: 2.82
      wake_equality: 12.99
      island: 148.42
        tree_edges: 17.07
        flood_fill: 118.25
      camlight: 20.23
      collision: [ 4126.84, 1021.73 ]
        convex_narrowphase: [ 3172.01, 554.60 ]
        nxn_broadphase: [ 913.96, 431.96 ]
        primitive_narrowphase: [ 24.41, 20.59 ]
      transmission: 16.82
      com_pos: 77.84
      flex: 2.76
      tendon: 2.82
    wake: 33.71
    update_sleep: 23.03
    fwd_velocity: 140.70
      com_vel: 37.68
      rne: 65.36
      tendon_bias: 2.80
      passive: 15.54
    sensor_vel: 2.82
    fwd_actuation: 19.41
    solve: 3357.70
      compute_island_mapping: 165.76
      solve_compact: 3183.53
        _compact_gather: 363.25
        mul_m: 35.81
        _compact_scatter: 27.45
          mul_m: 15.59
    sensor_acc: 18.47
    fwd_acceleration: 172.58
      xfrc_accumulate: 19.30
      update_active_dofs: 36.33
      smooth_solve_compact: 91.92
    sensor_pos: 2.80
  euler: 408.03
    update_sleep: 22.89
    sleep: 120.84
    fwd_velocity: 152.63
      com_vel: 41.43
      rne: 70.70
      tendon_bias: 2.79
      passive: 16.15
```

---

the result

```
mjwarp-viewer /tmp/benchmark_assets/aloha_clutter/scene_clutter.xml   --nworld=512   --nconmax=512   --nccdmax=64   --njmax=1024 --nvmax=64 --replay=/tmp/benchmark_assets/aloha_clutter/pick_clutter.npz -o "opt.sleep_tolerance=0.01"
```

https://github.com/user-attachments/assets/0ce366c6-76ca-4014-abc5-7d6ef93b7ff4
